### PR TITLE
make hitbox condition toggled by default

### DIFF
--- a/src/main/kotlin/org/polyfrost/polyhitbox/config/HitboxConfig.kt
+++ b/src/main/kotlin/org/polyfrost/polyhitbox/config/HitboxConfig.kt
@@ -8,7 +8,7 @@ import org.polyfrost.compose.render.PolyColor
  */
 class HitboxConfig {
     /** Show condition: 0 = Always, 1 = Toggled, 2 = Hovered, 3 = Never. */
-    var showCondition = 0
+    var showCondition = 1
 
     /** Overrides the [HitboxCategory.DEFAULT] styling for this category when enabled. */
     var overwriteDefault = false


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
makes it set to toggled by default. what i and what i imagine most people expect the mod to do

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
launch the game with default config

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Make hitbox condition toggled by default
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->